### PR TITLE
Pagination validation fix

### DIFF
--- a/src/docs/demos/pagination/pagination-demo.controller.js
+++ b/src/docs/demos/pagination/pagination-demo.controller.js
@@ -1,1 +1,10 @@
-export default class {}
+export default class {
+  constructor() {
+    this.size = '';
+    this.itemsPerPage = 10;
+    this.totalItems = 100;
+    this.visiblePageBuffer = 2;
+    this.currentPageUsability = 13;
+    this.currentPageBasic = 1;
+  }
+}

--- a/src/docs/demos/pagination/pagination-demo.html
+++ b/src/docs/demos/pagination/pagination-demo.html
@@ -1,33 +1,33 @@
-<div class="mb-4" ng-init="currentPageBasic = 1">
-    <h6>Basic Demo (Current Page: {{currentPageBasic}})</h6>
+<div class="mb-4">
+    <h6>Basic Demo (Current Page: {{this.currentPageBasic}})</h6>
     <p class="small">Use the inputs below to control how the component will be rendered.</p>
     <ngbs-pagination disabled="paginationDisabled"
-                     size="{{paginationSize}}"
-                     items-per-page="paginationItemsPerPage"
-                     total-items="paginationTotalItems"
-                     on-page-change="currentPageBasic = currentPage"
-                     visible-page-buffer="paginationVisiblePageBuffer"></ngbs-pagination>
+                     size="{{$ctrl.size}}"
+                     items-per-page="$ctrl.itemsPerPage"
+                     total-items="$ctrl.totalItems"
+                     on-page-change="this.currentPageBasic = currentPage"
+                     visible-page-buffer="$ctrl.visiblePageBuffer"></ngbs-pagination>
 </div>
 
 <div class="form-inline mb-4">
     <div class="form-group mr-2 mb-2">
         <label class="form-label mr-2" for="pagination-size">Size</label>
-        <select id="pagination-size" class="form-control" ng-init="paginationSize = ''" ng-model="paginationSize" ng-options="size.value as size.label for size in [{ value: '', label: 'Normal' }, { value: 'sm', label: 'Small' }, { value: 'lg', label: 'Large' }]"></select>
+        <select id="pagination-size" class="form-control" ng-model="$ctrl.size" ng-options="size.value as size.label for size in [{ value: '', label: 'Normal' }, { value: 'sm', label: 'Small' }, { value: 'lg', label: 'Large' }]"></select>
     </div>
 
     <div class="form-group mr-2 mb-2">
         <label class="form-label mr-2" for="pagination-items-per-page">Items/Page</label>
-        <input id="pagination-items-per-page" class="form-control" type="number" min="1" ng-init="paginationItemsPerPage = 10" ng-model="paginationItemsPerPage">
+        <input id="pagination-items-per-page" class="form-control" type="number" min="1" ng-model="$ctrl.itemsPerPage">
     </div>
 
     <div class="form-group mr-2 mb-2">
         <label class="form-label mr-2" for="pagination-total-items">Total Items</label>
-        <input id="pagination-total-items" class="form-control" type="number" min="1" ng-init="paginationTotalItems = 100" ng-model="paginationTotalItems">
+        <input id="pagination-total-items" class="form-control" type="number" min="1" ng-model="$ctrl.totalItems">
     </div>
     
     <div class="form-group mr-2 mb-2">
         <label class="form-label mr-2" for="pagination-visible-page-buffer">Visible Page Buffer</label>
-        <input id="pagination-visible-page-buffer" class="form-control" type="number" min="1" ng-init="paginationVisiblePageBuffer = 2" ng-model="paginationVisiblePageBuffer">
+        <input id="pagination-visible-page-buffer" class="form-control" type="number" min="1" ng-model="$ctrl.visiblePageBuffer">
     </div>
     
     <div class="form-group mr-2 mb-2">
@@ -39,8 +39,8 @@
     </div>
 </div>
 
-<div class="mb-4" ng-init="currentPageUsability = 13">
-    <h6>Usability Demo (Current Page: {{currentPageUsability}})</h6>
+<div class="mb-4">
+    <h6>Usability Demo (Current Page: {{this.currentPageUsability}})</h6>
     <p class="small">
         This illustrates the power of the <strong>visible-page-buffer</strong> attribute.
         As the user clicks through the pages, the width of the pagination component never shifts, allowing the user to page through the results without ever moving their mouse.

--- a/src/docs/demos/pagination/pagination-demo.html
+++ b/src/docs/demos/pagination/pagination-demo.html
@@ -1,11 +1,11 @@
 <div class="mb-4">
-    <h6>Basic Demo (Current Page: {{this.currentPageBasic}})</h6>
+    <h6>Basic Demo (Current Page: {{$ctrl.currentPageBasic}})</h6>
     <p class="small">Use the inputs below to control how the component will be rendered.</p>
     <ngbs-pagination disabled="paginationDisabled"
                      size="{{$ctrl.size}}"
                      items-per-page="$ctrl.itemsPerPage"
                      total-items="$ctrl.totalItems"
-                     on-page-change="this.currentPageBasic = currentPage"
+                     on-page-change="$ctrl.currentPageBasic = currentPage"
                      visible-page-buffer="$ctrl.visiblePageBuffer"></ngbs-pagination>
 </div>
 
@@ -40,7 +40,7 @@
 </div>
 
 <div class="mb-4">
-    <h6>Usability Demo (Current Page: {{this.currentPageUsability}})</h6>
+    <h6>Usability Demo (Current Page: {{$ctrl.currentPageUsability}})</h6>
     <p class="small">
         This illustrates the power of the <strong>visible-page-buffer</strong> attribute.
         As the user clicks through the pages, the width of the pagination component never shifts, allowing the user to page through the results without ever moving their mouse.

--- a/src/library/pagination/pagination.component.js
+++ b/src/library/pagination/pagination.component.js
@@ -11,34 +11,32 @@ class controller {
     this.totalPages = [];
   }
 
-  $onInit() {
-    // validate bindings
-    if (typeof this.currentPage !== 'number' || isFinite(this.currentPage) === false) {
-      this.$log.error('invalid ngbsPagination::currentPage:', this.currentPage, 'expecting a number');
-    }
-
-    if (typeof this.itemsPerPage !== 'number' || isFinite(this.itemsPerPage) === false) {
-      this.$log.error('invalid ngbsPagination::itemsPerPage:', this.itemsPerPage, 'expecting a number');
-    }
-
-    if (this.size && (typeof this.size !== 'string' || ['', 'lg', 'sm'].includes(this.size) === false)) {
-      this.$log.error('invalid ngbsPagination::size:', this.size, 'expecting sm or lg');
-    }
-
-    if (typeof this.totalItems !== 'number' || isFinite(this.totalItems) === false) {
-      this.$log.error('invalid ngbsPagination::totalItems:', this.totalItems, 'expecting a number');
-    }
-
-    if (typeof this.visiblePageBuffer !== 'number' || isFinite(this.visiblePageBuffer) === false) {
-      this.$log.error('invalid ngbsPagination::visiblePageBuffer:', this.visiblePageBuffer, 'expecting a number');
-    }
-  }
-
   $onChanges() {
     // provide defaults for when bad or no data is provided
     this.currentPage = this.currentPage || 1;
     this.size = this.size || '';
     this.visiblePageBuffer = this.visiblePageBuffer || this.visiblePageBuffer === 0 ? this.visiblePageBuffer : 3;
+
+    // (re)validate bindings
+    if (typeof this.currentPage !== 'number' || isFinite(this.currentPage) === false) {
+      this.$log.error('invalid ngbsPagination::currentPage:', JSON.stringify(this.currentPage), 'expecting a number');
+    }
+
+    if (typeof this.itemsPerPage !== 'number' || isFinite(this.itemsPerPage) === false) {
+      this.$log.error('invalid ngbsPagination::itemsPerPage:', JSON.stringify(this.itemsPerPage), 'expecting a number');
+    }
+
+    if (this.size && (typeof this.size !== 'string' || ['', 'lg', 'sm'].includes(this.size) === false)) {
+      this.$log.error('invalid ngbsPagination::size:', JSON.stringify(this.size), 'expecting "sm" or "lg"');
+    }
+
+    if (typeof this.totalItems !== 'number' || isFinite(this.totalItems) === false) {
+      this.$log.error('invalid ngbsPagination::totalItems:', JSON.stringify(this.totalItems), 'expecting a number');
+    }
+
+    if (typeof this.visiblePageBuffer !== 'number' || isFinite(this.visiblePageBuffer) === false) {
+      this.$log.error('invalid ngbsPagination::visiblePageBuffer:', JSON.stringify(this.visiblePageBuffer), 'expecting a number');
+    }
 
     // build pages array
     this.buildPages();


### PR DESCRIPTION
I moved validation to `$onChanges` because it makes more sense there.  Also got rid of `ng-init` as convenient as it was, it was throwing validation errors because it was created the properties after they were needed in the example.

If we're to put this validation everywhere, we should make some utilities classes to make it dead easy.  Something like...

    ValidationService.validateRequiredNumber(this, 'ngbsPagination', 'currentPage');
    ValidationService.validateOptionalNumber(this, 'ngbsPagination', 'currentPage');
    ValidationService.validateOptionalStringFromArray(this, 'ngbsPagination', 'size', ['', 'lg', 'sm']);

Or maybe similar... maybe less verbose.